### PR TITLE
docs: Fix incorrect listings of default mappings

### DIFF
--- a/doc/chapa.txt
+++ b/doc/chapa.txt
@@ -1,6 +1,6 @@
 *chapa.txt*   Visual selection, movement and commenting of Python Functions, Classes and Methods
 
-Simple approach to visual selection of Python blocks.
+Simple approach to visual selection of Python and JavaScript blocks.
 ==============================================================================
 CONTENTS                                                      *Chapa-contents*
 
@@ -13,81 +13,82 @@ CONTENTS                                                      *Chapa-contents*
 ==============================================================================
 1. Intro                                                          *ChapaIntro*
 
-After trying other plugins that were supposed to achieve this objective (and 
-fail) I decided to write it on my own. 
+After trying other plugins that were supposed to achieve this objective (and
+failing) I decided to write it on my own.
 
-No need to have VIM compiled with Python or Ruby support since this plugin uses 
+No need to have VIM compiled with Python or Ruby support since this plugin uses
 pure VIM syntax.
 
-Allows you to move to previous/next N class, function or method 
+Chapa allows you to:
 
-or visually select the next/previous N class, function or method 
+  - Move to previous/next N class, function or method
+  - Visually select the next/previous N class, function or method
+  - Toggle commenting out the next/previous N class, function or method.
 
-or comment (and toggle comments) out the next/previous N class, function 
-or method.
-
-As this is a "file-type plugin", it currently supports both Python and Ruby.
+It includes |filetype-plugins| supporting Python and JavaScript. For
+JavaScript, navigation/selection/commenting is only supported for functions
+at this time (given that idioms for "classes" and "methods" vary).
 
 ==============================================================================
 2. Usage                                                          *ChapaUsage*
 
 There are a couple of routes you can take: with or without default mappings.
 
-If you want to define your own mappings then no need to do anything else other 
+If you want to define your own mappings then no need to do anything else other
 than know the actual plugin calls (listed below).
 
-If you want the default mappings (also listed below) you need to add this to 
-your vimrc::
+If you want the default mappings (also listed below) you need to add this to
+your vimrc: >
 
     let g:chapa_default_mappings = 1
 
-You can also make the repeat actions for the plugin optional. If the above 
-variable is set but you don't like the repeat mappings, set the following 
-in your vimrc::
+You can also make the repeat actions for the plugin optional. If the above
+variable is set but you don't like the repeat mappings, set the following
+in your vimrc: >
 
     let g:chapa_no_repeat_mappings = 1
 
-You can map those callables to anything you want, but below is how the 
-defaults are mapped::
+You can map those callables to anything you want, but below is how the
+defaults are mapped: >
 
    " Function Movement
-   nmap fpf <Plug>ChapaNextFunction
-   nmap Fpf <Plug>ChapaPreviousFunction
+   nmap fnf <Plug>ChapaNextFunction
+   nmap fpf <Plug>ChapaPreviousFunction
 
    " Class Movement
-   nmap fpc <Plug>ChapaNextClass
-   nmap Fpc <Plug>ChapaPreviousClass
+   nmap fnc <Plug>ChapaNextClass
+   nmap fpc <Plug>ChapaPreviousClass
 
    " Method Movement
-   nmap fpm <Plug>ChapaNextMethod
-   nmap Fpm <Plug>ChapaPreviousMethod
+   nmap fnm <Plug>ChapaNextMethod
+   nmap fpm <Plug>ChapaPreviousMethod
 
-   " Class Visual Select 
-   nmap vanc <Plug>ChapaVisualNextClass
-   nmap vic <Plug>ChapaVisualThisClass 
-   nmap vapc <Plug>ChapaVisualPreviousClass
+   " Class Visual Select
+   nmap vnc <Plug>ChapaVisualNextClass
+   nmap vic <Plug>ChapaVisualThisClass
+   nmap vpc <Plug>ChapaVisualPreviousClass
 
    " Method Visual Select
-   nmap vanm <Plug>ChapaVisualNextMethod
+   nmap vnm <Plug>ChapaVisualNextMethod
    nmap vim <Plug>ChapaVisualThisMethod
-   nmap vapm <Plug>ChapaVisualPreviousMethod
+   nmap vpm <Plug>ChapaVisualPreviousMethod
 
    " Function Visual Select
-   nmap vanf <Plug>ChapaVisualNextFunction
+   nmap vnf <Plug>ChapaVisualNextFunction
    nmap vif <Plug>ChapaVisualThisFunction
-   nmap vapf <Plug>ChapaVisualPreviousFunction
+   nmap vpf <Plug>ChapaVisualPreviousFunction
 
    " Comment Class
    nmap cic <Plug>ChapaCommentThisClass
    nmap cnc <Plug>ChapaCommentNextClass
    nmap cpc <Plug>ChapaCommentPreviousClass
 
-   " Comment Method 
-   nmap cim <Plug>ChapaCommentThisMethod 
-   nmap cnm <Plug>ChapaCommentNextMethod 
-   nmap cpm <Plug>ChapaCommentPreviousMethod 
+   " Comment Method
+   nmap cim <Plug>ChapaCommentThisMethod
+   nmap cnm <Plug>ChapaCommentNextMethod
+   nmap cpm <Plug>ChapaCommentPreviousMethod
 
-   " Comment Function 
+   " Comment Function
    nmap cif <Plug>ChapaCommentThisFunction
    nmap cnf <Plug>ChapaCommentNextFunction
    nmap cpf <Plug>ChapaCommentPreviousFunction
@@ -112,41 +113,40 @@ defaults are mapped::
    nmap zpf <Plug>ChapaFoldPreviousFunction
 
 
-
-If the requested search (function, class or method) is not found, the call simply 
-returns and nothing should happen. However, there is an error message that should 
-display by default, explaining what it was supposed to search and in what 
+If the requested search (function, class or method) is not found, the call simply
+returns and nothing should happen. However, there is an error message that should
+display by default, explaining what it was supposed to search and in what
 direction.
 
-You can disable this by adding a chapa-specific variable in your vimrc::
+You can disable this by adding a chapa-specific variable in your vimrc: >
 
   let g:chapa_messages = 0
 
-You can also add a "count" to repeat the match N times. So if you want to go 
-to the 3rd previous class you would (with the mappings above) do something like::
+You can also add a "count" to repeat the match N times. So if you want to go
+to the 3rd previous class you would (with the mappings above) do something like: >
 
   3fpc
 
 The same applies for visual selections. If you want to visually select the 3rd
-next method, you would do it like::
+next method, you would do it like: >
 
   3vnm
 
 You can also toggle comments of a given class, method or function. To comment
-the next class::
+the next class: >
 
-  cnc 
+  cnc
 
 If the class is already commented, the command above will remove the comments.
 
 If you are moving around, the plugin allows you to repeat the forward or
-reverse (opposite to the original) move. For example, if you searched for the 
-next function like::
+reverse (opposite to the original) move. For example, if you searched for the
+next function like: >
 
-   fpf 
+   fpf
 
-Then ``<C-l>`` repeats that same command for you and moves you in the same 
-direction. If you want to go in the opposite movement, then ``<C-h>`` is your
+Then <C-l> repeats that same command for you and moves you in the same
+direction. If you want to go in the opposite movement, then <C-h> is your
 friend.
 
 
@@ -183,7 +183,10 @@ https://github.com/alfredodeza/chapa.vim/issues
 ==============================================================================
 5. Credits                                                      *ChapaCredits*
 
-A lot of the code for this plugin was adapted/copied from python.vim 
-and python_fn.vim authored by Jon Franklin and Mikael Berthe. 
+A lot of the code for this plugin was adapted/copied from python.vim
+and python_fn.vim authored by Jon Franklin and Mikael Berthe.
 
 ==============================================================================
+
+ vim:tw=78:ts=4:et:ft=help:norl:
+

--- a/ftplugin/javascript/chapa.vim
+++ b/ftplugin/javascript/chapa.vim
@@ -1,6 +1,6 @@
 " File:        chapa.vim
 " Description: Go to or visually select the next/previous class, method or
-"              function in Python.
+"              function in JavaScript.
 " Maintainer:  Alfredo Deza <alfredodeza AT gmail.com>
 " License:     MIT
 " Notes:       A lot of the code within was adapted/copied from python.vim 


### PR DESCRIPTION
I needed to review the help from within Vim, and I realized the mappings listed in the docs were not actually true to the source :smile:

Also made a few changes of reStructuredText to Vim help syntax—sorry for the noisy diff since I habitually zapped trailing whitespace too :weary: 